### PR TITLE
Fix range boundaries used to retrieve hash from different ScriptPubKey types

### DIFF
--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -318,12 +318,12 @@ impl TryFrom<PubkeyScript> for Compact {
                 .map_err(|_| Error::InvalidKeyData)?;
                 Pk(key)
             }
-            s if s.is_p2pkh() => Pkh(PubkeyHash::from_slice(&p[2..23])
+            s if s.is_p2pkh() => Pkh(PubkeyHash::from_slice(&p[3..23])
                 .expect("Reading hash from fixed slice failed")),
-            s if s.is_p2sh() => Sh(ScriptHash::from_slice(&p[1..22])
+            s if s.is_p2sh() => Sh(ScriptHash::from_slice(&p[2..22])
                 .expect("Reading hash from fixed slice failed")),
             s if s.is_v0_p2wpkh() => Wpkh(
-                WPubkeyHash::from_slice(&p[2..23])
+                WPubkeyHash::from_slice(&p[2..22])
                     .expect("Reading hash from fixed slice failed"),
             ),
             s if s.is_v0_p2wsh() => Wsh(WScriptHash::from_slice(&p[2..34])


### PR DESCRIPTION
This fixes an issue that I have bumped into while testing RGB node's `fungible validate` command: the process panics due to an out of range index.

Then I took the opportunity to review the range boundaries for all ScriptPubKey types and made the proper adjustments.