### PR TITLE
Remove regex and lazy static dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "amplify"
 version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,9 +123,7 @@ version = "0.5.0-alpha.3"
 dependencies = [
  "amplify",
  "bitcoin",
- "lazy_static",
  "miniscript",
- "regex",
  "serde",
  "serde_with",
  "slip132",
@@ -447,12 +436,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
-name = "memchr"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
-
-[[package]]
 name = "miniscript"
 version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,23 +705,6 @@ checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
  "rand_core 0.3.1",
 ]
-
-[[package]]
-name = "regex"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "ring"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,9 +281,7 @@ dependencies = [
  "bitcoin",
  "bitcoin_hd",
  "bitcoin_scripts",
- "lazy_static",
  "miniscript",
- "regex",
  "strict_encoding",
 ]
 

--- a/descriptors/Cargo.toml
+++ b/descriptors/Cargo.toml
@@ -19,6 +19,3 @@ bitcoin = "0.27.0"
 miniscript = { version = "6.0.1", features = ["compiler"] }
 bitcoin_hd = { version = "0.5.0-alpha.1", path = "../hd" }
 bitcoin_scripts = { version = "0.5.0-alpha.1", path = "../scripts" }
-# Remove these two
-regex = "1.5.4"
-lazy_static = "1.4.0"

--- a/descriptors/src/lib.rs
+++ b/descriptors/src/lib.rs
@@ -29,8 +29,6 @@
 extern crate amplify;
 #[macro_use]
 extern crate strict_encoding;
-#[macro_use]
-extern crate lazy_static;
 
 mod contract;
 mod deduction;

--- a/descriptors/src/typesystem.rs
+++ b/descriptors/src/typesystem.rs
@@ -114,7 +114,9 @@ impl ContentType {
 }
 
 impl From<FullType> for ContentType {
-    fn from(full: FullType) -> Self { Category::from(full).into() }
+    fn from(full: FullType) -> Self {
+        Category::from(full).into()
+    }
 }
 
 impl From<Category> for ContentType {
@@ -129,7 +131,9 @@ impl From<Category> for ContentType {
 }
 
 impl Default for ContentType {
-    fn default() -> Self { ContentType::SegWit }
+    fn default() -> Self {
+        ContentType::SegWit
+    }
 }
 
 impl FromStr for ContentType {
@@ -257,8 +261,8 @@ impl FromStr for FullType {
             "pk" => FullType::Pk,
             "pkh" => FullType::Pkh,
             "sh" => FullType::Sh,
-            "shWpkh" => FullType::ShWpkh,
-            "shWsh" => FullType::ShWsh,
+            "shwpkh" => FullType::ShWpkh,
+            "shwsh" => FullType::ShWsh,
             "wpkh" => FullType::Wpkh,
             "wsh" => FullType::Wsh,
             "tr" => FullType::Tr,

--- a/hd/Cargo.toml
+++ b/hd/Cargo.toml
@@ -20,9 +20,6 @@ miniscript = "6.0.1"
 slip132 = { version = "0.5.0-alpha.1", path = "../slip132" }
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
 serde_with = { version = "1.5", features = ["hex"], optional = true }
-# TODOL Remove the need in regex and lazy_static
-regex = "1.5.4"
-lazy_static = "1.4.0"
 
 [features]
 default = []

--- a/hd/src/components.rs
+++ b/hd/src/components.rs
@@ -169,7 +169,7 @@ impl FromStr for DerivationComponents {
             .map_err(|err| ComponentsParseError(err.to_string()))?;
 
         let (master_xpub, branch_path) = if let Some(caps) =
-            branch.and_then(|branch| DerivationStringParts::from_str(branch))
+            branch.and_then(DerivationStringParts::from_str)
         {
             let master_xpub = ExtendedPubKey::from_slip132_str(caps.xpub)
                 .map_err(|err| ComponentsParseError(err.to_string()))?;

--- a/hd/src/components.rs
+++ b/hd/src/components.rs
@@ -19,7 +19,6 @@ use std::str::FromStr;
 use bitcoin::secp256k1::{Secp256k1, Verification};
 use bitcoin::util::bip32::{ChildNumber, DerivationPath, ExtendedPubKey};
 use miniscript::MiniscriptKey;
-use regex::Regex;
 use slip132::FromSlip132;
 use strict_encoding::{self, StrictDecode, StrictEncode};
 
@@ -125,17 +124,6 @@ impl FromStr for DerivationComponents {
     type Err = ComponentsParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        lazy_static! {
-            static ref RE_DERIVATION: Regex = Regex::new(
-                r"(?x)^
-                \[(?P<xpub>[xyztuvXYZTUV]pub[1-9A-HJ-NP-Za-km-z]{107,108})\]
-                /(?P<deriv>([0-9]{1,10}[h']?)+)
-                (/(?P<range>\*|([0-9]{1,10}([,-][0-9]{1,10})*)))?
-                $",
-            )
-            .expect("Regexp expression for `DerivationComponents` is broken");
-        }
-
         let mut split = s.split('=');
         let (branch, terminal) =
             match (split.next(), split.next(), split.next()) {
@@ -153,7 +141,8 @@ impl FromStr for DerivationComponents {
                 }
             };
 
-        let caps = if let Some(caps) = RE_DERIVATION.captures(terminal) {
+        let caps = if let Some(caps) = DerivationStringParts::from_str(terminal)
+        {
             caps
         } else {
             return Err(ComponentsParseError(s!(
@@ -161,14 +150,9 @@ impl FromStr for DerivationComponents {
             )));
         };
 
-        let branch_xpub = ExtendedPubKey::from_slip132_str(
-            caps.name("xpub").expect("regexp engine is broken").as_str(),
-        )
-        .map_err(|err| ComponentsParseError(err.to_string()))?;
-        let terminal_path = caps
-            .name("deriv")
-            .expect("regexp engine is broken")
-            .as_str();
+        let branch_xpub = ExtendedPubKey::from_slip132_str(caps.xpub)
+            .map_err(|err| ComponentsParseError(err.to_string()))?;
+        let terminal_path = caps.derivation;
         let terminal_path =
             DerivationPath::from_str(&format!("m/{}", terminal_path))
                 .map_err(|err| ComponentsParseError(err.to_string()))?;
@@ -179,24 +163,17 @@ impl FromStr for DerivationComponents {
                                                 keys")));
         }
         let index_ranges = caps
-            .name("range")
-            .as_ref()
-            .map(regex::Match::as_str)
+            .range
             .map(DerivationRangeVec::from_str)
             .transpose()
             .map_err(|err| ComponentsParseError(err.to_string()))?;
 
         let (master_xpub, branch_path) = if let Some(caps) =
-            branch.and_then(|branch| RE_DERIVATION.captures(branch))
+            branch.and_then(|branch| DerivationStringParts::from_str(branch))
         {
-            let master_xpub = ExtendedPubKey::from_slip132_str(
-                caps.name("xpub").expect("regexp engine is broken").as_str(),
-            )
-            .map_err(|err| ComponentsParseError(err.to_string()))?;
-            let branch_path = caps
-                .name("deriv")
-                .expect("regexp engine is broken")
-                .as_str();
+            let master_xpub = ExtendedPubKey::from_slip132_str(caps.xpub)
+                .map_err(|err| ComponentsParseError(err.to_string()))?;
+            let branch_path = caps.derivation;
             let branch_path =
                 DerivationPath::from_str(&format!("m/{}", branch_path))
                     .map_err(|err| ComponentsParseError(err.to_string()))?;
@@ -218,5 +195,237 @@ impl FromStr for DerivationComponents {
 impl MiniscriptKey for DerivationComponents {
     type Hash = Self;
 
-    fn to_pubkeyhash(&self) -> Self::Hash { self.clone() }
+    fn to_pubkeyhash(&self) -> Self::Hash {
+        self.clone()
+    }
+}
+
+/// Components of a [DerivationComponents] string.
+/// Only used to split it into its different parts.
+#[derive(Debug, PartialEq, Eq)]
+struct DerivationStringParts<'a> {
+    /// xpub
+    xpub: &'a str,
+    /// Derivation path
+    derivation: &'a str,
+    /// Derivation range
+    range: Option<&'a str>,
+}
+
+impl<'a> DerivationStringParts<'a> {
+    /// Attempts to split `s` into its [DerivationStringParts].
+    /// `None` will be returned if `s` doesn't match the pattern.
+    fn from_str(s: &'a str) -> Option<DerivationStringParts> {
+        let mut closing = None::<usize>;
+        for (i, c) in s.chars().enumerate() {
+            // Check xpub until closing bracket is found
+            if closing.is_none() {
+                match i {
+                    0 => {
+                        if c != '[' {
+                            return None;
+                        }
+                    }
+                    // xpub content
+                    1..=111 => {
+                        if "0IOl".contains(c) || !c.is_ascii_alphanumeric() {
+                            return None;
+                        }
+                    }
+                    // Closing bracket
+                    112 | 113 => {
+                        if c == ']' {
+                            closing = Some(i);
+                        }
+                    }
+                    // xpub is too long
+                    _ => return None,
+                }
+                continue;
+            }
+
+            // Check derivation path and optional range
+            if let Some(closing) = closing {
+                let from_closing = i - closing;
+                match from_closing {
+                    1 => {
+                        if c != '/' {
+                            return None;
+                        }
+                    }
+                    2 => {
+                        if c != '*' && !c.is_ascii_digit() {
+                            return None;
+                        }
+                    }
+                    // Check invalid characters
+                    _ => {
+                        if !"*/h',-".contains(c) && !c.is_ascii_digit() {
+                            return None;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Determine path and range
+        if let Some(closing) = closing {
+            // Can't end on xpub's closing bracket
+            if s.len() <= closing + 1 {
+                return None;
+            }
+
+            if let Some(maybe_range) = s[closing..].rfind(|c| "*,-".contains(c))
+            {
+                let maybe_range = maybe_range + closing;
+                // Check if '*' range
+                if s[maybe_range..].starts_with('*')
+                    && s[maybe_range..].len() != 1
+                {
+                    // A range can only have one '*'
+                    return None;
+                } else if &s[maybe_range..] == "*" {
+                    return Some(Self {
+                        xpub: &s[1..closing],
+                        derivation: &s[closing + 2..maybe_range - 1],
+                        range: Some(&s[maybe_range..]),
+                    });
+                }
+
+                // It's a x-y or x,y range
+                // closing + 2 to skip "]/"
+                if let Some(real_range) = s[closing + 2..].rfind('/') {
+                    let real_range = real_range + closing + 2;
+                    return Some(Self {
+                        xpub: &s[1..closing],
+                        derivation: &s[closing + 2..real_range],
+                        range: Some(&s[real_range + 1..]),
+                    });
+                } else {
+                    // "*,-" needs to occur after a second '/'
+                    return None;
+                }
+            } else {
+                // No range detected
+                return Some(Self {
+                    xpub: &s[1..closing],
+                    derivation: &s[closing + 2..],
+                    range: None,
+                });
+            }
+        }
+
+        // Bracket enclosed xpub is not present
+        None
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::DerivationStringParts;
+
+    #[test]
+    fn derivationstringparts_from_str_returns_xpub_and_derivation() {
+        let derivation = "[xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw]/1";
+        let hardened_derivation = "[xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw]/1/878'/1971h/420";
+        let no_derivation = "[xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw]";
+
+        let expected_derivation = Some(DerivationStringParts{
+            xpub: "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw",
+            derivation: "1",
+            range: None,
+        });
+        let expected_hardened_derivation = Some(DerivationStringParts{
+            xpub: "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw",
+            derivation: "1/878'/1971h/420",
+            range: None,
+        });
+        let expected_no_derivation = None::<DerivationStringParts>;
+
+        let result_derivation = DerivationStringParts::from_str(derivation);
+        let result_hardened_derivation =
+            DerivationStringParts::from_str(hardened_derivation);
+        let result_no_derivation =
+            DerivationStringParts::from_str(no_derivation);
+
+        assert_eq!(result_derivation, expected_derivation);
+        assert_eq!(result_hardened_derivation, expected_hardened_derivation);
+        assert_eq!(result_no_derivation, expected_no_derivation);
+    }
+
+    #[test]
+    fn derivationstringparts_from_str_returns_xpub_derivation_and_range() {
+        let hyphen_range = "[xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw]/1/878'/1971h/420/0-1000";
+        let comma_range = "[xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw]/1/878'/1971h/420/0,1000";
+        let star_range = "[xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw]/1/878'/1971h/420/*";
+        let invalid_range = "[xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw]/1/878'/1971h/420/0#1000";
+
+        let expected_hyphen = Some(DerivationStringParts{
+            xpub: "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw",
+            derivation: "1/878'/1971h/420",
+            range: Some("0-1000"),
+        });
+        let expected_comma = Some(DerivationStringParts{
+            xpub: "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw",
+            derivation: "1/878'/1971h/420",
+            range: Some("0,1000"),
+        });
+        let expected_star = Some(DerivationStringParts{
+            xpub: "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw",
+            derivation: "1/878'/1971h/420",
+            range: Some("*"),
+        });
+        let expected_invalid = None::<DerivationStringParts>;
+
+        let result_hyphen = DerivationStringParts::from_str(hyphen_range);
+        let result_comma = DerivationStringParts::from_str(comma_range);
+        let result_star = DerivationStringParts::from_str(star_range);
+        let result_invalid = DerivationStringParts::from_str(invalid_range);
+
+        assert_eq!(result_hyphen, expected_hyphen);
+        assert_eq!(result_comma, expected_comma);
+        assert_eq!(result_star, expected_star);
+        assert_eq!(result_invalid, expected_invalid);
+    }
+
+    #[test]
+    fn derivationstringparts_from_str_returns_none_when_empty() {
+        let s = "";
+
+        let expected = None::<DerivationStringParts>;
+        let result = DerivationStringParts::from_str(s);
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn derivationstringparts_from_str_returns_none_when_bracket_missing() {
+        let no_brackets = "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw/1/878'/1971h/420/10,1000";
+        let no_left_bracket = "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw]/1/878'/1971h/420/10,1000";
+        let no_right_bracket = "[xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw/1/878'/1971h/420/10,1000";
+
+        let expected = None::<DerivationStringParts>;
+        let result_no_brackets = DerivationStringParts::from_str(no_brackets);
+        let result_left_bracket =
+            DerivationStringParts::from_str(no_left_bracket);
+        let result_right_bracket =
+            DerivationStringParts::from_str(no_right_bracket);
+
+        assert_eq!(result_no_brackets, expected);
+        assert_eq!(result_left_bracket, expected);
+        assert_eq!(result_right_bracket, expected);
+    }
+
+    #[test]
+    fn derivationstringparts_from_str_returns_none_when_wrong_xpub_len() {
+        let too_short = "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDn/1/878'/1971h/420/10,1000";
+        let too_long = "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnwww]/1/878'/1971h/420/10,1000";
+
+        let expected = None::<DerivationStringParts>;
+        let result_too_short = DerivationStringParts::from_str(too_short);
+        let result_too_long = DerivationStringParts::from_str(too_long);
+
+        assert_eq!(result_too_short, expected);
+        assert_eq!(result_too_long, expected);
+    }
 }

--- a/hd/src/lib.rs
+++ b/hd/src/lib.rs
@@ -20,8 +20,6 @@
 extern crate amplify;
 #[macro_use]
 extern crate strict_encoding;
-#[macro_use]
-extern crate lazy_static;
 
 #[cfg(feature = "serde")]
 #[macro_use]

--- a/hd/src/pubkeychain.rs
+++ b/hd/src/pubkeychain.rs
@@ -209,9 +209,8 @@ impl FromStr for PubkeyChain {
                     branch_segment.next(),
                 ) {
                     (index, Some(xpub), None, seal, None) => {
-                        let branch_index = index
-                            .map(|index| HardenedIndex::from_str(index))
-                            .transpose()?;
+                        let branch_index =
+                            index.map(HardenedIndex::from_str).transpose()?;
                         let xpub = &xpub[1..xpub.len() - 1]; // Trimming square brackets
                         let branch_xpub =
                             ExtendedPubKey::from_slip132_str(xpub)?;
@@ -251,7 +250,9 @@ impl FromStr for PubkeyChain {
 impl MiniscriptKey for PubkeyChain {
     type Hash = Self;
 
-    fn to_pubkeyhash(&self) -> Self::Hash { self.clone() }
+    fn to_pubkeyhash(&self) -> Self::Hash {
+        self.clone()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Issue #4 

I tried to replicate the regex parsing with two separate functions which return structs that hold the previous regex groups. I have only replaced the regex captures with those structs and did not modify the logic of the affected functions in another way.