### PR TITLE
Linter fixes

### DIFF
--- a/descriptors/src/lib.rs
+++ b/descriptors/src/lib.rs
@@ -17,6 +17,7 @@
 // Coding conventions
 #![recursion_limit = "256"]
 #![deny(dead_code, /* missing_docs, */ warnings)]
+#![allow(clippy::init_numbered_fields)]
 
 //! General workflow for working with ScriptPubkey* types:
 //! ```text

--- a/hd/src/indexes.rs
+++ b/hd/src/indexes.rs
@@ -409,7 +409,10 @@ pub enum AccountStep {
     #[from(u8)]
     #[from(u16)]
     #[from]
-    Normal(UnhardenedIndex),
+    Normal {
+        /// Unhardened derivation 0-based index value
+        index: UnhardenedIndex,
+    },
 
     /// Derivation segment is defined by a hardened index
     Hardened {
@@ -470,7 +473,7 @@ impl SegmentIndexes for AccountStep {
     fn from_index(index: impl Into<u32>) -> Result<Self, bip32::Error> {
         let index = index.into();
         Ok(UnhardenedIndex::from_index(index)
-            .map(Self::Normal)
+            .map(|index| Self::Normal { index })
             .unwrap_or_else(|_| {
                 Self::hardened(
                     HardenedIndex::from_index(index)
@@ -482,7 +485,7 @@ impl SegmentIndexes for AccountStep {
     #[inline]
     fn first_index(&self) -> u32 {
         match self {
-            AccountStep::Normal(index) => SegmentIndexes::first_index(index),
+            AccountStep::Normal { index } => SegmentIndexes::first_index(index),
             AccountStep::Hardened { index, .. } => SegmentIndexes::first_index(index),
         }
     }
@@ -497,7 +500,7 @@ impl SegmentIndexes for AccountStep {
     #[inline]
     fn first_derivation_value(&self) -> u32 {
         match self {
-            AccountStep::Normal(index) => index.first_derivation_value(),
+            AccountStep::Normal { index } => index.first_derivation_value(),
             AccountStep::Hardened { index, .. } => index.first_derivation_value(),
         }
     }
@@ -505,7 +508,7 @@ impl SegmentIndexes for AccountStep {
     #[inline]
     fn checked_add_assign(&mut self, add: impl Into<u32>) -> Option<u32> {
         match self {
-            AccountStep::Normal(index) => index.checked_add_assign(add),
+            AccountStep::Normal { index } => index.checked_add_assign(add),
             AccountStep::Hardened { index, .. } => index.checked_add_assign(add),
         }
     }
@@ -513,7 +516,7 @@ impl SegmentIndexes for AccountStep {
     #[inline]
     fn checked_sub_assign(&mut self, sub: impl Into<u32>) -> Option<u32> {
         match self {
-            AccountStep::Normal(index) => index.checked_sub_assign(sub),
+            AccountStep::Normal { index } => index.checked_sub_assign(sub),
             AccountStep::Hardened { index, .. } => index.checked_sub_assign(sub),
         }
     }
@@ -521,7 +524,7 @@ impl SegmentIndexes for AccountStep {
     #[inline]
     fn is_hardened(&self) -> bool {
         match self {
-            AccountStep::Normal(_) => false,
+            AccountStep::Normal { .. } => false,
             AccountStep::Hardened { .. } => true,
         }
     }
@@ -530,7 +533,7 @@ impl SegmentIndexes for AccountStep {
 impl Display for AccountStep {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            AccountStep::Normal(index) => Display::fmt(index, f),
+            AccountStep::Normal { index } => Display::fmt(index, f),
             AccountStep::Hardened {
                 index,
                 xpub_ref: XpubRef::Unknown,
@@ -567,9 +570,9 @@ impl TryFrom<ChildNumber> for AccountStep {
     /// values to be in range, we need to re-test them here
     fn try_from(child_number: ChildNumber) -> Result<Self, Self::Error> {
         Ok(match child_number {
-            ChildNumber::Normal { index } => {
-                AccountStep::Normal(UnhardenedIndex::from_index(index)?)
-            }
+            ChildNumber::Normal { index } => AccountStep::Normal {
+                index: UnhardenedIndex::from_index(index)?,
+            },
             ChildNumber::Hardened { index } => {
                 AccountStep::hardened(HardenedIndex::from_index(index)?)
             }
@@ -584,7 +587,7 @@ impl From<AccountStep> for ChildNumber {
 impl From<&AccountStep> for ChildNumber {
     fn from(value: &AccountStep) -> Self {
         match value {
-            AccountStep::Normal(index) => ChildNumber::Normal {
+            AccountStep::Normal { index } => ChildNumber::Normal {
                 index: index.first_index(),
             },
             AccountStep::Hardened { index, .. } => ChildNumber::Hardened {
@@ -604,7 +607,7 @@ impl TryFrom<AccountStep> for UnhardenedIndex {
 
     fn try_from(value: AccountStep) -> Result<Self, Self::Error> {
         match value {
-            AccountStep::Normal(index) => Ok(index),
+            AccountStep::Normal { index } => Ok(index),
             AccountStep::Hardened { index, .. } => {
                 Err(bip32::Error::InvalidChildNumber(index.first_index()))
             }
@@ -617,7 +620,7 @@ impl TryFrom<AccountStep> for HardenedIndex {
 
     fn try_from(value: AccountStep) -> Result<Self, Self::Error> {
         match value {
-            AccountStep::Normal(index) => {
+            AccountStep::Normal { index } => {
                 Err(bip32::Error::InvalidChildNumber(index.first_index()))
             }
             AccountStep::Hardened { index, .. } => Ok(index),
@@ -642,7 +645,7 @@ pub enum TerminalStep {
     #[display(inner)]
     Range(IndexRangeList<UnhardenedIndex>),
 
-    /// Wildcrard implying full range of unhardened indexes
+    /// Wildcard implying full range of unhardened indexes
     #[display("*")]
     Wildcard,
 }

--- a/hd/src/lib.rs
+++ b/hd/src/lib.rs
@@ -20,6 +20,7 @@
 // Coding conventions
 #![recursion_limit = "256"]
 #![deny(dead_code, missing_docs, warnings)]
+#![allow(clippy::init_numbered_fields)]
 
 #[macro_use]
 extern crate amplify;

--- a/libbitcoin/src/signer.rs
+++ b/libbitcoin/src/signer.rs
@@ -102,6 +102,7 @@ impl string_result_t {
     pub fn success(data: impl ToString) -> string_result_t {
         let (code, details) = match CString::new(data.to_string()) {
             Ok(s) => (error_t::success, result_details_t { data: s.into_raw() }),
+            #[allow(clippy::needless_borrow)]
             Err(err) => (error_t::invalid_result_data, (&err).into()),
         };
         string_result_t { code, details }

--- a/libbitcoin/src/signer.rs
+++ b/libbitcoin/src/signer.rs
@@ -102,8 +102,11 @@ impl string_result_t {
     pub fn success(data: impl ToString) -> string_result_t {
         let (code, details) = match CString::new(data.to_string()) {
             Ok(s) => (error_t::success, result_details_t { data: s.into_raw() }),
-            #[allow(clippy::needless_borrow)]
-            Err(err) => (error_t::invalid_result_data, (&err).into()),
+            Err(err) => (error_t::invalid_result_data, result_details_t {
+                data: CString::new(err.to_string())
+                    .expect("Null byte in string_result_t success code doc comments")
+                    .into_raw(),
+            }),
         };
         string_result_t { code, details }
     }

--- a/psbt/src/sign/signer.rs
+++ b/psbt/src/sign/signer.rs
@@ -383,7 +383,7 @@ where
         }
         (CompositeDescrType::Wsh, Some(witness_script))
         | (CompositeDescrType::ShWsh, Some(witness_script)) => {
-            sig_hasher.segwit_signature_hash(index, &witness_script, spent_value, sighash_type)?
+            sig_hasher.segwit_signature_hash(index, witness_script, spent_value, sighash_type)?
         }
         (CompositeDescrType::Wsh, None) | (CompositeDescrType::ShWsh, None) => {
             return Err(SignInputError::NoWitnessScript)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "1.59"

--- a/scripts/src/parser.rs
+++ b/scripts/src/parser.rs
@@ -177,7 +177,7 @@ pub(crate) mod test {
             sk[2] = (i >> 16) as u8;
 
             ret.push(secp256k1::PublicKey::from_secret_key(
-                &secp256k1::SECP256K1,
+                secp256k1::SECP256K1,
                 &secp256k1::SecretKey::from_slice(&sk[..]).unwrap(),
             ));
         }
@@ -198,7 +198,7 @@ pub(crate) mod test {
     }
 
     pub(crate) fn no_keys_or_hashes_suite(proc: fn(LockScript) -> ()) {
-        let sha_hash = sha256::Hash::hash(&"(nearly)random string".as_bytes());
+        let sha_hash = sha256::Hash::hash("(nearly)random string".as_bytes());
         let dummy_hashes: Vec<hash160::Hash> = (1..13)
             .map(|i| hash160::Hash::from_inner([i; 20]))
             .collect();
@@ -364,10 +364,7 @@ pub(crate) mod test {
     #[test]
     fn test_script_parse_complex_keys() {
         complex_keys_suite(|lockscript, keys| {
-            assert_eq!(
-                lockscript.extract_pubkeys::<Segwitv0>().unwrap(),
-                keys.clone()
-            );
+            assert_eq!(lockscript.extract_pubkeys::<Segwitv0>().unwrap(), keys);
             assert_eq!(
                 lockscript.extract_pubkey_hash_set::<Segwitv0>().unwrap(),
                 (BTreeSet::from_iter(keys), BTreeSet::new())
@@ -387,10 +384,7 @@ pub(crate) mod test {
     #[test]
     fn test_script_parse_complex_script() {
         complex_suite(|lockscript, keys| {
-            assert_eq!(
-                lockscript.extract_pubkeys::<Segwitv0>().unwrap(),
-                keys.clone()
-            );
+            assert_eq!(lockscript.extract_pubkeys::<Segwitv0>().unwrap(), keys);
             assert_eq!(
                 lockscript.extract_pubkeyset::<Segwitv0>().unwrap(),
                 BTreeSet::from_iter(keys)

--- a/slip132/src/lib.rs
+++ b/slip132/src/lib.rs
@@ -359,13 +359,14 @@ impl KeyApplication {
         }
         let bip48_purpose = ChildNumber::Hardened { index: 48 };
         if path.len() >= 4 && path[0] == bip48_purpose {
-            return match path[3] {
+            match path[3] {
                 ChildNumber::Hardened { index: 1 } => Some(KeyApplication::NestedMultisig),
                 ChildNumber::Hardened { index: 2 } => Some(KeyApplication::SegWitMiltisig),
                 _ => None,
-            };
+            }
+        } else {
+            None
         }
-        return None;
     }
 
     pub fn to_derivation_path(&self) -> Option<DerivationPath> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 // Coding conventions
 #![recursion_limit = "256"]
 #![deny(dead_code, /* missing_docs, */ warnings)]
+#![allow(clippy::init_numbered_fields)]
 
 #[macro_use]
 extern crate amplify;


### PR DESCRIPTION
One notable lint:
https://rust-lang.github.io/rust-clippy/master/index.html#init_numbered_fields
Which was why I made the AccountStep enum more consistent. I did that work as a separate commit because it's a bit more involved change.

There were a couple of other cases where I could've tried fixing the lint by adding named fields instead of a positional tuple struct to the enum member, which would fix the issue, but I became concerned it was indicative of an oversight in the strict encoding portion of the client side validation library. I've made an issue for that here:
https://github.com/LNP-BP/client_side_validation/issues/54