### PR TITLE
Turn strict_encoding optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,21 @@ version = "3.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba2ec14f4fb838e9ddace42fa5944bb1ee4dff8477494ba48c5f874e16caf27a"
 dependencies = [
- "amplify_derive",
- "amplify_num",
- "amplify_syn",
+ "amplify_derive 2.11.3",
+ "amplify_num 0.4.1",
+ "amplify_syn 1.1.6",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "amplify"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8629db306c0bbeb0a402e2918bdcf0026b5ddb24c46460f3bf5410b350d98710"
+dependencies = [
+ "amplify_derive 4.0.0",
+ "amplify_num 0.5.0",
+ "ascii",
  "rand",
  "serde",
  "serde_json",
@@ -37,7 +49,19 @@ version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c3de270e75f27a4468a7c344070109046656e85cb522141f7d40ab4b83803ac"
 dependencies = [
- "amplify_syn",
+ "amplify_syn 1.1.6",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "amplify_derive"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759dcbfaf94d838367a86d493ec34ccc8aa6fe365cb7880d6bf89006de24d9c1"
+dependencies = [
+ "amplify_syn 2.0.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -48,6 +72,12 @@ name = "amplify_num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27d3d00d3d115395a7a8a4dc045feb7aa82b641e485f7e15f4e67ac16f4f56d"
+
+[[package]]
+name = "amplify_num"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddce3bc63e807ea02065e8d8b702695f3d302ae4158baddff8b0ce5c73947251"
 dependencies = [
  "serde",
 ]
@@ -57,6 +87,17 @@ name = "amplify_syn"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da24db1445cc7bc3842fa072c2d51fe5b25b812b6a572d65842a4c72e87221ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "amplify_syn"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7736fb8d473c0d83098b5bac44df6a561e20470375cd8bcae30516dc889fd62a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -80,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.5.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -94,15 +135,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
 dependencies = [
  "utf8parse",
 ]
@@ -118,12 +159,21 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "2.1.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
  "windows-sys",
+]
+
+[[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -171,10 +221,9 @@ dependencies = [
 [[package]]
 name = "bitcoin_blockchain"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f2d44b94b4add196f2f8bfa314873b9ff767dd16c7879c8d99c8a5eaeb242a"
+source = "git+https://github.com/crisdut/bp-foundation?branch=feat/bump-amplify-4#75535db4372c770b758b125442ba2721c5815d26"
 dependencies = [
- "amplify",
+ "amplify 4.5.0",
  "chrono",
  "serde",
  "strict_encoding",
@@ -193,7 +242,7 @@ dependencies = [
 name = "bitcoin_hd"
 version = "0.10.1"
 dependencies = [
- "amplify",
+ "amplify 4.5.0",
  "bitcoin",
  "miniscript",
  "secp256k1",
@@ -219,7 +268,7 @@ dependencies = [
 name = "bitcoin_onchain"
 version = "0.10.1"
 dependencies = [
- "amplify",
+ "amplify 4.5.0",
  "bitcoin",
  "bitcoin_hd",
  "chrono",
@@ -233,10 +282,9 @@ dependencies = [
 [[package]]
 name = "bitcoin_scripts"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4ab9af39abb9d9dfb52c3926bde921da7e2289a2a8a7fca35369ecc0148054"
+source = "git+https://github.com/crisdut/bp-foundation?branch=feat/bump-amplify-4#75535db4372c770b758b125442ba2721c5815d26"
 dependencies = [
- "amplify",
+ "amplify 4.5.0",
  "bitcoin",
  "secp256k1",
  "serde",
@@ -253,21 +301,21 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
@@ -286,16 +334,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.29"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87d9d13be47a5b7c3907137f1290b0459a7f80efb26be8c52afb11963bccb02"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
- "time 0.1.45",
  "wasm-bindgen",
  "windows-targets",
 ]
@@ -312,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.2"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
+checksum = "ac495e00dcec98c83465d5ad66c5c4fabd652fd6686e7c6269b117e729a6f17b"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -322,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.2"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+checksum = "c77ed9a32a62e6ca27175d00d29d05ca32e396ea1eb5fb01d8256b669cec7663"
 dependencies = [
  "anstream",
  "anstyle",
@@ -334,21 +381,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.2"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "colorchoice"
@@ -375,9 +422,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "3fbc60abd742b35f2492f808e1abbb83d45f72db402e14c55057edc9c7b1e9e4"
 dependencies = [
  "libc",
 ]
@@ -413,7 +460,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.31",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -424,15 +471,16 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
+ "powerfmt",
  "serde",
 ]
 
@@ -441,7 +489,7 @@ name = "descriptor-wallet"
 version = "0.10.1"
 dependencies = [
  "aes",
- "amplify",
+ "amplify 4.5.0",
  "bip39",
  "bitcoin",
  "bitcoin_blockchain",
@@ -468,7 +516,7 @@ dependencies = [
 name = "descriptors"
 version = "0.10.1"
 dependencies = [
- "amplify",
+ "amplify 4.5.0",
  "bitcoin",
  "bitcoin_blockchain",
  "bitcoin_hd",
@@ -504,7 +552,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2293d9a54744b73b753fad2e3c16295345504dc230696ee8aa5dbfd276ab4"
 dependencies = [
- "amplify",
+ "amplify 3.14.2",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -518,23 +566,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -561,7 +598,7 @@ checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -572,9 +609,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "heck"
@@ -584,9 +621,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex"
@@ -596,16 +633,16 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -636,12 +673,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -693,21 +730,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -718,6 +755,12 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "memchr"
+version = "2.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
@@ -739,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
@@ -764,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
@@ -782,6 +825,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,9 +838,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -800,7 +849,7 @@ dependencies = [
 name = "psbt"
 version = "0.10.1"
 dependencies = [
- "amplify",
+ "amplify 4.5.0",
  "bitcoin",
  "bitcoin_blockchain",
  "bitcoin_hd",
@@ -915,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -931,10 +980,24 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
- "untrusted",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -960,11 +1023,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.11"
+version = "0.38.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0c3dde1fc030af041adc40e79c0e7fbcf431dd24870053d187d7c66e4b87453"
+checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -978,7 +1041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
  "log",
- "ring",
+ "ring 0.16.20",
  "sct",
  "webpki",
 ]
@@ -997,12 +1060,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.5",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -1028,32 +1091,41 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
+dependencies = [
  "serde",
 ]
 
@@ -1080,7 +1152,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.28",
+ "time",
 ]
 
 [[package]]
@@ -1092,7 +1164,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1101,7 +1173,7 @@ version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
  "itoa",
  "ryu",
  "serde",
@@ -1112,7 +1184,7 @@ dependencies = [
 name = "slip132"
 version = "0.10.1"
 dependencies = [
- "amplify",
+ "amplify 4.5.0",
  "bitcoin",
  "serde",
  "serde_with",
@@ -1121,15 +1193,21 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stability"
@@ -1147,7 +1225,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0be7060b49729cd0b9b2391114632ef64c363a4055d91de049f5555b466193bb"
 dependencies = [
- "amplify",
+ "amplify 3.14.2",
  "bitcoin",
  "bitcoin_hashes",
  "chrono",
@@ -1161,7 +1239,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34c9cabafb397fc1144463228ad4ba57c3c670a0117505fe59b15d8c74449716"
 dependencies = [
- "amplify_syn",
+ "amplify_syn 1.1.6",
  "encoding_derive_helpers",
  "proc-macro2",
  "syn 1.0.109",
@@ -1173,7 +1251,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fc369cd865314a3416556e3669d3f2d2e41c6e80cc838208c84a34f74d79234"
 dependencies = [
- "amplify",
+ "amplify 3.14.2",
  "strict_encoding",
 ]
 
@@ -1206,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.31"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1217,29 +1295,19 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.11"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
+checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
 
 [[package]]
 name = "time"
-version = "0.1.45"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
  "itoa",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -1247,15 +1315,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
 ]
@@ -1277,24 +1345,49 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "2ef75d881185fd2df4a040793927c153d863651108a93c7e17a9e591baa95cc6"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "typenum"
-version = "1.16.0"
+name = "toml_edit"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "380f9e8120405471f7c9ad1860a713ef5ece6a670c7eae39225e477340f32fc4"
+dependencies = [
+ "indexmap 2.0.2",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -1324,6 +1417,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,12 +1433,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -1368,7 +1461,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -1390,7 +1483,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1413,12 +1506,12 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.5",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -1453,10 +1546,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.48.0"
+name = "windows-core"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets",
 ]
@@ -1526,3 +1619,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winnow"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,16 @@ edition = "2021"
 rust-version = "1.65.0" # due to let .. else
 
 [workspace.dependencies]
-amplify = "3.14.2"
-strict_encoding = "0.9.0"
+amplify = "4.0.0"
 secp256k1 = { version = "0.24.3", features = ["global-context"] }
 bitcoin = "0.29.2"
-bitcoin_scripts = "0.10.0"
-bitcoin_blockchain = "0.10.0"
-bitcoin_hd = { version = "0.10.0", path = "./hd" }
-bitcoin_onchain = { version = "0.10.0", path = "./onchain" }
-descriptors = { version = "0.10.0", path = "./descriptors", default-features = false }
-psbt = { version = "0.10.0", path = "./psbt", default-features = false }
-slip132 = { version = "0.10.0", path = "./slip132" }
+bitcoin_scripts = { version = "0.10.0", default-features = false }
+bitcoin_blockchain = { version = "0.10.0", default-features = false }
+bitcoin_hd = { version = "0.10.1", path = "./hd", default-features = false }
+bitcoin_onchain = { version = "0.10.1", path = "./onchain", default-features = false }
+descriptors = { version = "0.10.1", path = "./descriptors", default-features = false }
+psbt = { version = "0.10.1", path = "./psbt", default-features = false }
+slip132 = { version = "0.10.1", path = "./slip132" }
 miniscript_crate = { package = "miniscript", version = "9.0.1" }
 chrono = "0.4.19"
 
@@ -106,7 +105,6 @@ all = [
 ]
 mobile = ["miniscript", "compiler", "electrum", "strict_encoding", "hot", "construct"]
 miniscript = [
-    "strict_encoding_crate/miniscript",
     "bitcoin_hd/miniscript",
     "bitcoin_onchain/miniscript_descriptors",
     "descriptors/miniscript",
@@ -118,8 +116,15 @@ electrum = [
     "bitcoin_onchain/electrum"
 ]
 strict_encoding = [
-    "slip132/strict_encoding"
+    "strict_encoding_crate/miniscript",
+    "bitcoin_blockchain/strict_encoding",
+    "bitcoin_hd/strict_encoding",    
+    "bitcoin_scripts/strict_encoding",
+    "slip132/strict_encoding",
+    "psbt/strict_encoding",
+    "descriptors/strict_encoding",
 ]
+
 sign = ["psbt/sign"]
 construct = ["psbt/construct"]
 hot = [
@@ -152,3 +157,8 @@ serde = [
     "psbt/serde",
     "descriptors/serde"
 ]
+
+[patch.crates-io]
+# Remove after merge and release https://github.com/BP-WG/bitcoin_foundation/pull/20
+bitcoin_scripts = { git = "https://github.com/crisdut/bp-foundation", branch = "feat/bump-amplify-4" }
+bitcoin_blockchain = { git = "https://github.com/crisdut/bp-foundation", branch = "feat/bump-amplify-4" }

--- a/descriptors/Cargo.toml
+++ b/descriptors/Cargo.toml
@@ -15,7 +15,6 @@ exclude = []
 
 [dependencies]
 amplify = { workspace = true }
-strict_encoding = { workspace = true }
 bitcoin = { workspace = true }
 bitcoin_scripts = { workspace = true }
 bitcoin_blockchain = { workspace = true }
@@ -24,12 +23,14 @@ miniscript_crate = { workspace = true, features = ["compiler"], optional = true 
 chrono = { workspace = true }
 serde_crate = { package = "serde", version = "1", optional = true }
 serde_with = { version = "2.3", features = ["hex"], optional = true }
+strict_encoding = { version = "0.9.0", optional = true }
 
 [features]
 all = [
     "rand",
     "miniscript",
-    "serde"
+    "serde",
+    "strict_encoding",
 ]
 default = []
 rand = [

--- a/descriptors/src/descriptor.rs
+++ b/descriptors/src/descriptor.rs
@@ -12,7 +12,6 @@
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
-use amplify::Wrapper;
 use bitcoin::hashes::Hash;
 use bitcoin::schnorr::{TweakedPublicKey, UntweakedPublicKey};
 use bitcoin::secp256k1::{self, Secp256k1, Verification};
@@ -30,9 +29,11 @@ use miniscript::descriptor::DescriptorType;
 use miniscript::policy::compiler::CompilerError;
 #[cfg(feature = "miniscript")]
 use miniscript::{Descriptor, MiniscriptKey, Terminal};
+#[cfg(feature = "strict_encoding")]
+use strict_encoding::{self, StrictDecode, StrictEncode};
 
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -97,7 +98,7 @@ impl DescriptorClass {
 #[derive(
     Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash, Default, Debug, Display
 )]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[repr(u8)]
 pub enum SpkClass {
     #[display("bare")]
@@ -203,7 +204,7 @@ impl FromStr for SpkClass {
     serde(crate = "serde_crate")
 )]
 #[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display)]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[repr(u8)]
 pub enum CompositeDescrType {
     #[display("bare")]
@@ -328,7 +329,7 @@ impl FromStr for CompositeDescrType {
     serde(crate = "serde_crate")
 )]
 #[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display)]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[repr(u8)]
 pub enum OuterDescrType {
     #[display("bare")]
@@ -410,8 +411,8 @@ impl FromStr for OuterDescrType {
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display)]
-#[derive(StrictEncode, StrictDecode)]
 #[repr(u8)]
 pub enum InnerDescrType {
     #[display("bare")]
@@ -494,7 +495,7 @@ impl FromStr for InnerDescrType {
     serde(crate = "serde_crate")
 )]
 #[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Default)]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[repr(C)]
 pub struct DescrVariants {
     pub bare: bool,
@@ -566,7 +567,7 @@ impl DescrVariants {
 }
 
 #[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Debug, Display)]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[non_exhaustive]
 pub enum ScriptPubkeyDescr {
     #[display("bare({0})", alt = "bare({0:#})")]
@@ -663,7 +664,7 @@ impl TryFrom<PubkeyScript> for ScriptPubkeyDescr {
     type Error = UnsupportedScriptPubkey;
 
     fn try_from(spk: PubkeyScript) -> Result<Self, Self::Error> {
-        let script = spk.as_inner();
+        let script = spk.clone();
         let bytes = script.as_bytes();
         match (&spk, spk.witness_version()) {
             (spk, _) if spk.is_p2pk() && script.len() == 67 => Ok(ScriptPubkeyDescr::Pk(
@@ -707,7 +708,7 @@ impl TryFrom<PubkeyScript> for ScriptPubkeyDescr {
 /// Descriptors exposing bare scripts (unlike [`miniscript::Descriptor`] which
 /// uses miniscript representation of the scripts).
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[non_exhaustive]
 pub enum BareDescriptor {
     Bare(PubkeyScript),

--- a/descriptors/src/input.rs
+++ b/descriptors/src/input.rs
@@ -21,7 +21,7 @@ use bitcoin_blockchain::locks::{self, SeqNo};
 use bitcoin_hd::{DerivationSubpath, UnhardenedIndex};
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 pub struct InputDescriptor {
     pub outpoint: OutPoint,
     pub terminal: DerivationSubpath<UnhardenedIndex>,

--- a/descriptors/src/lib.rs
+++ b/descriptors/src/lib.rs
@@ -22,6 +22,7 @@
 
 #[macro_use]
 extern crate amplify;
+#[cfg(feature = "strict_encoding")]
 #[macro_use]
 extern crate strict_encoding;
 #[cfg(feature = "miniscript")]

--- a/hd/Cargo.toml
+++ b/hd/Cargo.toml
@@ -15,15 +15,15 @@ exclude = []
 
 [dependencies]
 amplify = { workspace = true }
-strict_encoding = { workspace = true }
 bitcoin = { workspace = true }
 secp256k1 = { workspace = true }
 miniscript_crate = { workspace = true, optional = true }
 slip132 = { workspace = true }
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
+strict_encoding = { version = "0.9.0", optional = true }
 
 [features]
 default = []
-all = ["serde", "miniscript"]
+all = ["serde", "miniscript", "strict_encoding"]
 serde = ["serde_crate", "bitcoin/serde"]
 miniscript = ["miniscript_crate"]

--- a/hd/src/account.rs
+++ b/hd/src/account.rs
@@ -69,7 +69,7 @@ pub trait DerivePublicKey {
 /// HD wallet account guaranteeing key derivation without access to the
 /// private keys.
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 pub struct DerivationAccount {
     /// Reference to the extended master public key, if known
     pub master: XpubRef,

--- a/hd/src/indexes.rs
+++ b/hd/src/indexes.rs
@@ -14,6 +14,7 @@ use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
 use bitcoin::util::bip32::{self, ChildNumber, Error};
+#[cfg(feature = "strict_encoding")]
 use strict_encoding::{self, StrictDecode, StrictEncode};
 
 use super::{IndexRangeList, XpubRef, HARDENED_INDEX_BOUNDARY};
@@ -239,7 +240,7 @@ pub struct UnhardenedIndexExpected(pub HardenedIndex);
 #[derive(
     Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Debug, Hash, Default, Display, From
 )]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[display(inner)]
 pub struct UnhardenedIndex(
     #[from(u8)]
@@ -352,7 +353,7 @@ impl From<UnhardenedIndex> for ChildNumber {
 #[derive(
     Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Default, Display, From
 )]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[display("{0}h", alt = "{0}'")]
 pub struct HardenedIndex(
     /// The inner index value; always reduced by [`HARDENED_INDEX_BOUNDARY`]
@@ -464,7 +465,7 @@ impl From<HardenedIndex> for ChildNumber {
 /// Derivation segment for the account part of the derivation path as defined by
 /// LNPBP-32 standard
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, From)]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -738,7 +739,7 @@ impl TryFrom<AccountStep> for HardenedIndex {
     serde(crate = "serde_crate", rename_all = "camelCase")
 )]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Display, From)]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 pub enum TerminalStep {
     /// Specific unhardened index
     #[from]

--- a/hd/src/lib.rs
+++ b/hd/src/lib.rs
@@ -20,6 +20,7 @@
 
 #[macro_use]
 extern crate amplify;
+#[cfg(feature = "strict_encoding")]
 #[macro_use]
 extern crate strict_encoding;
 

--- a/hd/src/path.rs
+++ b/hd/src/path.rs
@@ -12,10 +12,12 @@
 use core::fmt::{self, Display, Formatter};
 use core::str::FromStr;
 use std::borrow::{Borrow, BorrowMut};
+#[cfg(feature = "strict_encoding")]
 use std::io;
 use std::ops::{Deref, DerefMut};
 
 use bitcoin::util::bip32;
+#[cfg(feature = "strict_encoding")]
 use strict_encoding::{self, StrictDecode, StrictEncode};
 
 use crate::SegmentIndexes;
@@ -99,6 +101,7 @@ where
     fn borrow_mut(&mut self) -> &mut [Segment] { &mut self.0 }
 }
 
+#[cfg(feature = "strict_encoding")]
 impl<Segment> StrictEncode for DerivationSubpath<Segment>
 where
     Segment: SegmentIndexes + StrictEncode,
@@ -109,6 +112,7 @@ where
     }
 }
 
+#[cfg(feature = "strict_encoding")]
 impl<Segment> StrictDecode for DerivationSubpath<Segment>
 where
     Segment: SegmentIndexes + StrictDecode,

--- a/hd/src/ranges.rs
+++ b/hd/src/ranges.rs
@@ -12,12 +12,14 @@
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
 use std::fmt::{self, Display, Formatter};
+#[cfg(feature = "strict_encoding")]
 use std::io;
 use std::ops::RangeInclusive;
 use std::str::FromStr;
 
 use amplify::Wrapper;
 use bitcoin::util::bip32;
+#[cfg(feature = "strict_encoding")]
 use strict_encoding::{self, StrictDecode, StrictEncode};
 
 use crate::SegmentIndexes;
@@ -156,6 +158,7 @@ where
     fn is_hardened(&self) -> bool { self.first_range().is_hardened() }
 }
 
+#[cfg(feature = "strict_encoding")]
 impl<Index> StrictEncode for IndexRangeList<Index>
 where
     Index: SegmentIndexes + StrictEncode,
@@ -167,6 +170,7 @@ where
     }
 }
 
+#[cfg(feature = "strict_encoding")]
 impl<Index> StrictDecode for IndexRangeList<Index>
 where
     Index: SegmentIndexes + StrictDecode,
@@ -266,6 +270,7 @@ where
     serde(crate = "serde_crate", transparent)
 )]
 #[derive(Wrapper, Clone, PartialEq, Eq, Hash, Debug, From)]
+#[wrapper(Deref)]
 pub struct IndexRange<Index>(RangeInclusive<Index>)
 where
     Index: SegmentIndexes;
@@ -425,6 +430,7 @@ where
     }
 }
 
+#[cfg(feature = "strict_encoding")]
 impl<Index> StrictEncode for IndexRange<Index>
 where
     Index: SegmentIndexes + StrictEncode,
@@ -434,6 +440,7 @@ where
     }
 }
 
+#[cfg(feature = "strict_encoding")]
 impl<Index> StrictDecode for IndexRange<Index>
 where
     Index: SegmentIndexes + StrictDecode,

--- a/hd/src/standards.rs
+++ b/hd/src/standards.rs
@@ -129,7 +129,7 @@ impl FromStr for DerivationBlockchain {
 
 /// Specific derivation scheme after BIP-43 standards
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display)]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[cfg_attr(feature = "clap", derive(ArgEnum))]
 #[cfg_attr(
     feature = "serde",

--- a/hd/src/xkey.rs
+++ b/hd/src/xkey.rs
@@ -89,7 +89,7 @@ pub enum NonStandardDerivation {
 
 /// Deterministic part of the extended public key descriptor
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),

--- a/hd/src/xpubref.rs
+++ b/hd/src/xpubref.rs
@@ -19,7 +19,7 @@ use bitcoin::XpubIdentifier;
 #[derive(
     Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Default, Debug, Display, From
 )]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),

--- a/libbitcoin/Cargo.toml
+++ b/libbitcoin/Cargo.toml
@@ -15,7 +15,7 @@ readme = "../README.md"
 [dependencies]
 libc = "0.2"
 lazy_static = "1.4"
-amplify = "3.14.2"
+amplify = "4.0.0"
 amplify_derive = "2.11.2"
 bitcoin = "0.28.2"
 bip39 = "2.0.0"

--- a/onchain/Cargo.toml
+++ b/onchain/Cargo.toml
@@ -15,7 +15,6 @@ exclude = []
 
 [dependencies]
 amplify = { workspace = true }
-strict_encoding = { workspace = true }
 bitcoin = { workspace = true }
 bitcoin_hd = { workspace = true }
 descriptors = { workspace = true, optional = true }
@@ -23,10 +22,11 @@ miniscript_crate = { workspace = true, optional = true }
 electrum-client = { version = "0.14.0", optional = true }
 chrono = { workspace = true }
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
+strict_encoding = { version = "0.9.0", optional = true }
 
 [features]
 default = []
-all = ["miniscript_descriptors", "electrum", "serde"]
+all = ["miniscript_descriptors", "electrum", "serde", "strict_encoding"]
 miniscript = ["miniscript_crate"]
 miniscript_descriptors = [
     "miniscript",

--- a/onchain/src/blockchain.rs
+++ b/onchain/src/blockchain.rs
@@ -20,6 +20,7 @@ use bitcoin::{BlockHash, Network, OutPoint};
 use chrono::NaiveDateTime;
 #[cfg(feature = "electrum")]
 use electrum_client::ListUnspentRes;
+#[cfg(feature = "strict_encoding")]
 use strict_encoding::{StrictDecode, StrictEncode};
 
 /// Error parsing string representation of wallet data/structure
@@ -37,7 +38,7 @@ pub struct ParseError;
 
 /// Block mining information
 #[derive(Getters, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display)]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[display("{block_height}#{block_hash}@{timestamp}")]
 pub struct TimeHeight {
     timestamp: NaiveDateTime,
@@ -82,7 +83,7 @@ impl FromStr for TimeHeight {
 #[derive(
     Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Default, Debug, Display
 )]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 pub enum MiningStatus {
     /// Transaction mining status is undefined
     #[default]
@@ -109,7 +110,7 @@ pub enum MiningStatus {
     serde(crate = "serde_crate")
 )]
 #[derive(Getters, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display)]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[display("{amount}@{outpoint}")]
 pub struct Utxo {
     /// Status of the transaction containing this UTXO

--- a/onchain/src/lib.rs
+++ b/onchain/src/lib.rs
@@ -18,6 +18,7 @@
 
 #[macro_use]
 extern crate amplify;
+#[cfg(feature = "strict_encoding")]
 #[macro_use]
 extern crate strict_encoding;
 #[cfg(feature = "serde")]

--- a/onchain/src/network.rs
+++ b/onchain/src/network.rs
@@ -16,7 +16,7 @@ use bitcoin_hd::standards::DerivationBlockchain;
 #[derive(
     Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug, Display
 )]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),

--- a/psbt/Cargo.toml
+++ b/psbt/Cargo.toml
@@ -15,7 +15,6 @@ exclude = []
 
 [dependencies]
 amplify = { workspace = true }
-strict_encoding = { workspace = true }
 bitcoin = { workspace = true, features = ["base64"] }
 bitcoin_scripts = { workspace = true }
 bitcoin_blockchain = { workspace = true }
@@ -25,16 +24,18 @@ descriptors = { workspace = true, optional = true }
 miniscript_crate = { workspace = true, optional = true }
 serde_crate = { package = "serde", version = "1", optional = true }
 serde_with = { version = "2.3", features = ["hex"], optional = true }
+strict_encoding = { version = "0.9.0", optional = true }
 
 [dev-dependencies]
-strict_encoding_test = "0.9.0"
+strict_encoding_test  = { version = "0.9.0" }
 
 [features]
 default = []
 all = [
     "serde",
     "construct",
-    "sign"
+    "sign",
+    "strict_encoding"
 ]
 miniscript = ["miniscript_crate"]
 construct = [

--- a/psbt/src/global.rs
+++ b/psbt/src/global.rs
@@ -27,7 +27,7 @@ use crate::{raw, Error, FeeError, Input, Output, PsbtVersion, TxError};
 // TODO: Do manual serde and strict encoding implementation to check the
 //       deserialized values
 #[derive(Clone, Eq, PartialEq, Debug, Default)]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),

--- a/psbt/src/input.rs
+++ b/psbt/src/input.rs
@@ -31,7 +31,7 @@ use crate::{raw, InputMatchError, TxinError};
 
 // TODO: Do manual serde implementation to check the deserialized values
 #[derive(Clone, Eq, PartialEq, Debug, Default)]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),

--- a/psbt/src/lib.rs
+++ b/psbt/src/lib.rs
@@ -30,6 +30,7 @@ extern crate amplify;
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde_crate as serde;
+#[cfg(feature = "strict_encoding")]
 #[macro_use]
 extern crate strict_encoding;
 #[cfg(feature = "miniscript")]
@@ -66,8 +67,11 @@ pub use proprietary::{
 
 /// Version of the PSBT (V0 stands for BIP174-defined version; V2 - for BIP370).
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Default)]
-#[derive(StrictEncode, StrictDecode)]
-#[strict_encoding(repr = u32)]
+#[cfg_attr(
+    feature = "strict_encoding",
+    derive(StrictEncode, StrictDecode),
+    strict_encoding(repr = u32),
+)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),

--- a/psbt/src/output.rs
+++ b/psbt/src/output.rs
@@ -24,7 +24,7 @@ use crate::v0::OutputV0;
 
 // TODO: Do manual serde implementation to check the deserialized values
 #[derive(Clone, Eq, PartialEq, Debug, Default)]
-#[derive(StrictEncode, StrictDecode)]
+#[cfg_attr(feature = "strict_encoding", derive(StrictEncode, StrictDecode))]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),

--- a/psbt/src/proprietary.rs
+++ b/psbt/src/proprietary.rs
@@ -37,9 +37,9 @@ pub enum ProprietaryKeyError {
     /// parts:
     /// 1) key location, in form of `input(no)`, `output(no)`, or `global`;
     /// 2) key type, in form of `prefix(no)`;
-    /// 3) key-value pair, in form of `key:value`, where both key and value
-    ///    must be hexadecimal bytestrings; one of them may be omitted
-    ///    (for instance, `:value` or `key:`).
+    /// 3) key-value pair, in form of `key:value`, where both key and value must
+    ///    be hexadecimal bytestrings; one of them may be omitted (for instance,
+    ///    `:value` or `key:`).
     ///
     /// If the proprietary key does not have associated data, the third part of
     /// the descriptor must be fully omitted.

--- a/psbt/src/sign/signer.rs
+++ b/psbt/src/sign/signer.rs
@@ -340,7 +340,7 @@ impl Input {
         let spent_value = prevout.value;
 
         // Check script_pubkey match and requirements
-        let script_pubkey = PubkeyScript::from_inner(prevout.script_pubkey.clone());
+        let script_pubkey = PubkeyScript::from(prevout.script_pubkey.clone());
         let witness_script = self.witness_script.as_ref();
         let redeem_script = self.redeem_script.as_ref();
 
@@ -441,7 +441,7 @@ impl Input {
         let index = self.index();
 
         // Check script_pubkey match
-        let script_pubkey = PubkeyScript::from_inner(self.input_prevout()?.script_pubkey.clone());
+        let script_pubkey = PubkeyScript::from(self.input_prevout()?.script_pubkey.clone());
         if let Some(internal_key) = self.tap_internal_key {
             if script_pubkey
                 != Script::new_v1_p2tr(provider.secp_context(), internal_key, self.tap_merkle_root)

--- a/slip132/Cargo.toml
+++ b/slip132/Cargo.toml
@@ -19,10 +19,10 @@ path = "src/lib.rs"
 
 [dependencies]
 amplify = { workspace = true }
-strict_encoding = { workspace = true, optional = true }
 bitcoin = { workspace = true }
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
 serde_with = { version = "2.3", features = ["hex"], optional = true }
+strict_encoding = { version = "0.9.0", optional = true }
 
 [features]
 default = []

--- a/slip132/src/lib.rs
+++ b/slip132/src/lib.rs
@@ -19,8 +19,7 @@
 #[macro_use]
 extern crate amplify;
 #[cfg(feature = "strict_encoding")]
-#[macro_use]
-extern crate strict_encoding;
+use strict_encoding::{self, StrictDecode, StrictEncode};
 
 #[cfg(feature = "serde")]
 #[macro_use]


### PR DESCRIPTION
**Description**

To avoid incompatibly  with wasm complication and amplify >= 4.0, this PR intent turn _strict_encoding_ feature optional in `psbt` and `descriptors` crates.


CC @cryptoquick @dr-orlovsky 